### PR TITLE
Fix streaming API usage

### DIFF
--- a/docs/checklists/CHECKLIST-bugfix-streaming.md
+++ b/docs/checklists/CHECKLIST-bugfix-streaming.md
@@ -1,0 +1,5 @@
+# Checklist - Streaming Bug Fix
+
+- ✅ Update `generateText` in `lib/textGeneration.ts` to handle `generateContentStream` returning an AsyncGenerator.
+- ✅ Verify no remaining references to `.stream` or `.response`.
+- ✅ Run `npm install` and `npm run build` to ensure the app builds successfully.

--- a/lib/textGeneration.ts
+++ b/lib/textGeneration.ts
@@ -129,19 +129,22 @@ export async function generateText(
   }
 
   try {
-    let genAiResponse: GenerateContentResponse;
+    let genAiResponse: GenerateContentResponse | undefined;
     let collectedText = '';
     if (stream || onToken) {
       const streamResp = await ai.models.generateContentStream(request);
-      for await (const chunk of streamResp.stream) {
+      for await (const chunk of streamResp) {
         const token = chunk.text || '';
         collectedText += token;
+        genAiResponse = chunk;
         if (onToken) onToken(token);
         if (onInteraction) {
           onInteraction({type: 'TOKEN', data: token, modelName});
         }
       }
-      genAiResponse = await streamResp.response;
+      if (!genAiResponse) {
+        throw new Error('No response received from streaming');
+      }
       // Overwrite text with collected text for convenience
       (genAiResponse as any).text = collectedText;
     } else {


### PR DESCRIPTION
## Summary
- handle generateContentStream returning an AsyncGenerator
- add a streaming bugfix checklist

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68698847a5b88323948ccb45751611d8