### PR TITLE
Fix streaming API usage

### DIFF
--- a/docs/checklists/CHECKLIST-bugfix-streaming.md
+++ b/docs/checklists/CHECKLIST-bugfix-streaming.md
@@ -1,0 +1,6 @@
+# Checklist - Streaming Bug Fix
+
+- ✅ Update `generateText` in `lib/textGeneration.ts` to handle `generateContentStream` returning an AsyncGenerator.
+- ✅ Verify no remaining references to `.stream` or `.response`.
+- ✅ Run `npm install` and `npm run build` to ensure the app builds successfully.
+- ✅ Preserve streaming text without mutating `GenerateContentResponse.text` by collecting text separately and returning it.


### PR DESCRIPTION
## Summary
- handle generateContentStream returning an AsyncGenerator
- return collected streaming text directly instead of mutating the response
- update the streaming bugfix checklist

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68698847a5b88323948ccb45751611d8