### PR TITLE
Fix OpenRouter authentication by adding explicit Authorization header

### DIFF
--- a/lib/textGeneration.ts
+++ b/lib/textGeneration.ts
@@ -86,20 +86,14 @@ export async function generateText(
   const fullPrompt = basePrompt + (additionalUserText ? `\n${additionalUserText}` : '');
 
   if (provider === 'openrouter') {
-
-
-
-  let effectiveApiKey = apiKey;
-
-
-
     const openai = new OpenAI({
-      apiKey: effectiveApiKey || '',
+      apiKey: apiKey || '',
       baseURL: 'https://openrouter.ai/api/v1',
       dangerouslyAllowBrowser: true,
       defaultHeaders: {
         "HTTP-Referer": window.location.origin,
-        "X-Title": "Video to Learning App"
+        "X-Title": "Video to Learning App",
+        "Authorization": `Bearer ${apiKey || ''}`
       }
     });
 


### PR DESCRIPTION


## Summary
This PR fixes the 401 "No auth credentials found" error when using OpenRouter models by ensuring the API key is properly passed in the Authorization header.

## Changes
- Added explicit `Authorization: Bearer <apiKey>` header to OpenRouter API requests
- Simplified the OpenRouter client initialization by removing redundant variables
- Ensured consistent authentication across all OpenRouter models (free and paid)

## Testing
- Verified that all OpenRouter models now properly authenticate using the provided API key
- Confirmed that 401 authentication errors are resolved

## Related Issues
Fixes authentication issues with OpenRouter models reported in testing.

## Checklist
- [x] Code compiles correctly
- [x] Authentication works for all OpenRouter models
- [x] No breaking changes to existing functionality
- [x] Ready for review

