### PR TITLE
Fix OpenRouter authentication by removing redundant Authorization header

### DIFF
--- a/lib/textGeneration.ts
+++ b/lib/textGeneration.ts
@@ -96,8 +96,7 @@ export async function generateText(
       dangerouslyAllowBrowser: true,
       defaultHeaders: {
         "HTTP-Referer": window.location.origin,
-        "X-Title": "Video to Learning App",
-        "Authorization": `Bearer ${apiKey}`
+        "X-Title": "Video to Learning App"
       }
     });
 


### PR DESCRIPTION




## Summary
This PR fixes the 401 "No auth credentials found" error when using OpenRouter models by removing the redundant Authorization header and allowing the OpenAI SDK to handle authentication automatically.

## Changes
- Removed explicit `Authorization: Bearer ${apiKey}` header from OpenRouter client configuration
- Let the OpenAI SDK automatically handle the Authorization header based on the provided `apiKey`
- Maintained existing validation for API key presence
- Kept debug logging for troubleshooting authentication issues

## Technical Details
The OpenAI SDK automatically adds the `Authorization: Bearer <apiKey>` header when the `apiKey` parameter is provided in the constructor. Manually adding this header was causing potential conflicts or duplication.

## Testing
- Verified that OpenRouter models authenticate properly when a valid API key is provided
- Confirmed that 401 authentication errors are resolved
- Ensured no breaking changes to existing functionality

## Related Issues
Fixes authentication issues with OpenRouter models reported in testing.

## Checklist
- [x] Code compiles correctly
- [x] Authentication works for all OpenRouter models
- [x] No breaking changes to existing functionality
- [x] Ready for review



