### PR TITLE
Restore Authorization header for OpenRouter authentication

### DIFF
--- a/lib/textGeneration.ts
+++ b/lib/textGeneration.ts
@@ -96,7 +96,8 @@ export async function generateText(
       dangerouslyAllowBrowser: true,
       defaultHeaders: {
         "HTTP-Referer": window.location.origin,
-        "X-Title": "Video to Learning App"
+        "X-Title": "Video to Learning App",
+        "Authorization": `Bearer ${apiKey}`
       }
     });
 


### PR DESCRIPTION

## Summary
This PR restores the explicit Authorization header for OpenRouter authentication after discovering that the OpenAI SDK does not automatically add authentication headers when using custom base URLs.

## Problem
The OpenAI SDK only automatically adds the Authorization header when connecting to the official OpenAI endpoint (api.openai.com). When using a custom baseURL like OpenRouter's (https://openrouter.ai/api/v1), the SDK does not inject the Bearer token, resulting in 401 "No auth credentials found" errors.

## Solution
- Restored the explicit `Authorization: Bearer ${apiKey}` header in the OpenRouter client configuration
- This ensures proper authentication when using OpenRouter models
- Maintained all other existing headers and functionality

## Technical Details
When `baseURL` is set to a non-OpenAI endpoint, the OpenAI SDK treats it as a custom API and does not automatically handle authentication. The Authorization header must be explicitly provided in the `defaultHeaders` configuration.

## Testing
- Verified that OpenRouter models now authenticate properly
- Confirmed 401 errors are resolved
- Tested with multiple OpenRouter models (moonshotai/kimi-k2:free, xai/grok-4, etc.)

## Related Issues
Fixes the persistent 401 authentication errors with OpenRouter models that occurred after removing the manual Authorization header.

## Checklist
- [x] Authorization header restored for OpenRouter
- [x] 401 errors resolved
- [x] No breaking changes to other providers
- [x] Ready for review
